### PR TITLE
Update Assemble.py

### DIFF
--- a/tasks/Assemble.py
+++ b/tasks/Assemble.py
@@ -31,3 +31,63 @@ class Assemble(Task):
             logger.warning(
                 "No traps selected. Please create a QTrapGroup.")
         self.assembler.traps = group
+    
+    #### Method to set assembler tunables and determine where targets are. Override this in subclass, or it won't do anything!
+    def aim(self):
+        pass
+    
+    #### Method to set assembler tunables (stepRate, smooth, etc), and declare any parameters needed in 'aim' (i.e. a circle's radius, etc)
+    def config(self):
+        pass
+    
+    def dotask(self):
+        if self.assembler.traps is not None:
+            self.config()   # Configure assembler + declare 'aim' parameters
+            self.assembler.targets = self.aim()
+            self.assembler.start()
+            
+def prompt(str):
+    qparam, ok = QInputDialog.getDouble(self.parent,'Parameters', str)
+        if ok:
+            return qparam
+        else:
+            return None
+
+        
+#### Example of how to subclass:
+class Circle(Assemble):
+    
+    def config(self):
+         # Set tunables
+        self.assembler.smooth = True
+        self.assembler.stepRate = 15         # [steps/s]
+        self.assembler.stepSize = .2         # [um]
+        self.assembler.particleSpacing = 2   # [um]
+        self.assembler.gridSpacing = .5      # [um]
+        self.assembler.zrange = (5, -10)     # [um]
+        self.assembler.tmax = 300            # [steps]
+        
+         # Set 'aim' parameters
+        self.r = 200
+         # Or, prompt the user for an input:
+        self.r = prompt('radius (pixels):')
+         # Or, if you want to make sure the user gets it right, add this loop...
+        emphasis = '!'
+        while self.r is None:
+            self.r = prompt("That's not a double - try again" + emphasis)
+            emphasis = emphasis + '!'
+       
+                
+    def aim(self):
+        vertices = []
+        r = self.r      #### Remember - we need to instantiate parameters in config! (Or, you can technically do it in aim)
+        xc, yc = (self.cgh.xc, self.cgh.yc)
+        ntraps = len(self.assembler.traps.flatten()
+        for i in range(ntraps):
+            theta = 2*np.pi*(idx+1) / ntraps
+            vertices.append(np.array([xc + radius*np.cos(theta),
+                                      yc + radius*np.sin(theta),
+                                      0]))
+            return vertices
+                     
+#### And that's it! init, dotask, initialize, etc are all defined in the parent, so you only need to override aim (and semi-optionally, config)


### PR DESCRIPTION
Here's an idea for implementing Assemble more generally. Since all subclasses need to do is configure the assembler and set the targets, we can generalize so that the only thing the user needs to override is an "aim" method that returns target vertices, and a "config" method that sets tunables (i.e. stepRate) and also declares any parameters used in 'aim'.

Feedback appreciated - I'm not sure if this is the optimal structure. For example, we don't technically need two methods; we could just set all the assembler parameters and aim parameters in "aim" and override that. Or, we technically can just override "dotask"  instead of defining a new function 'aim'. Thoughts...?