### PR TITLE
Create QSubtaskManager.py

### DIFF
--- a/tasks/QSubtaskManager.py
+++ b/tasks/QSubtaskManager.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from PyQt5.QtCore import (QObject, pyqtSlot, pyqtSignal, pyqtProperty)
+from ..QTaskmanager import QTaskmanager
+from collections import deque
+import importlib
+
+import logging
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+class QSubtaskManager(QTaskmanager):
+
+    """ QTaskmanager feeds frames from the video screen to any tasks from 
+    the main task library. Likewise, QSubtaskManager feeds output from a 
+    specific QTask to any QSubtasks in the respective sublibrary.
+    
+    source is a QTask (usually non-blocking) which includes its own sigNewFrame().
+    
+    """
+
+
+    def __init__(self, source=None, sublib=None):
+        super(QSubtaskManager, self).__init__(parent)
+        self.source = source
+        self.sublib = sublib
+        self.source.sigDone.connect(self.cleanup)
+
+    def registerTask(self, taskname, blocking=True, **kwargs):
+        super(QSubtaskManager, self).registerTask(self, taskname + '.' + sublib, blocking=blocking, **kwargs)
+        
+    @pyqtSlot()
+    def cleanup(self):
+        self.clearTasks()
+        self.source.sigDone.disconnect(self.cleanup)


### PR DESCRIPTION
Idea for structuring subtasks. If, for instance, vision.py is a QTask that detects particles, and another task is designed to read vision signals and plot positions on a graph, then how will the subtask connect to the Vision task's output? One way would be to make a new task manager for vision's subtasks, but with vision's output as a source. (I.e. vision has its own signal sigNewFrame(Trajectories) that passes trajectories to its subtasks). 

To make this work, the task manager needs to pass subtasks to the appropriate subtask manager. We can do this by organizing like-subtasks into the same subfolder in 'lib'.
The main task manager also needs to properly shut down the subtask manager when the "source" task (i.e. vision) ends (i.e. recieves sigDone() from the source).